### PR TITLE
Add energy32

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -50,7 +50,3 @@ allprojects {
 task clean(type: Delete) {
     delete rootProject.buildDir
 }
-
-// Maven Central publishing
-apply plugin: 'io.github.gradle-nexus.publish-plugin'
-apply from: rootProject.file('gradle/publish-root.gradle')

--- a/mesh/build.gradle
+++ b/mesh/build.gradle
@@ -70,14 +70,3 @@ dependencies {
     androidTestImplementation 'androidx.room:room-testing:2.3.0'
 
 }
-// === Maven Central configuration ===
-// The following file exists only when Android BLE Library project is opened, but not
-// when the module is loaded to a different project.
-if (rootProject.file('gradle/publish-module.gradle').exists()) {
-    ext {
-        POM_ARTIFACT_ID="mesh"
-        POM_NAME="A Bluetooth Mesh library for Android"
-        POM_PACKAGING="aar"
-    }
-    apply from: rootProject.file('gradle/publish-module.gradle')
-}

--- a/mesh/src/main/java/no/nordicsemi/android/mesh/sensorutils/DeviceProperty.java
+++ b/mesh/src/main/java/no/nordicsemi/android/mesh/sensorutils/DeviceProperty.java
@@ -1048,6 +1048,9 @@ public enum DeviceProperty {
                 return new FixedString(data, offset, 36);
             case LUMINAIRE_IDENTIFICATION_STRING:
                 return new FixedString(data, offset, 64);
+            case ACTIVE_ENERGY_LOAD_SIDE:
+            case PRECISE_TOTAL_DEVICE_ENERGY_USE:
+                return new Energy32(data, offset);
             default:
                 return new UnknownCharacteristic(data, offset, length);
         }

--- a/mesh/src/main/java/no/nordicsemi/android/mesh/sensorutils/Energy32.java
+++ b/mesh/src/main/java/no/nordicsemi/android/mesh/sensorutils/Energy32.java
@@ -1,0 +1,54 @@
+package no.nordicsemi.android.mesh.sensorutils;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.RestrictTo;
+
+import java.util.Arrays;
+
+/**
+ * The Energy 32 characteristic is used to represent a measure of energy in units of kilowatt-hours.
+ */
+public class Energy32 extends DevicePropertyCharacteristic<Double> {
+
+    @RestrictTo(RestrictTo.Scope.LIBRARY)
+    public Energy32(@NonNull final byte[] data, final int offset) {
+        super(data, offset);
+        long bits = 0;
+        byte[] bytes = Arrays.copyOfRange(data, offset, offset + getLength());
+        for (byte b : bytes) bits = (bits >> 8) | (((long) b & 0xFF) << 24);
+        if (bits == 0xFFFFFFFFL || bits == 0xFFFFFFFEL) this.value = null;
+        else this.value = ((double) bits) / 1000.0d;
+    }
+
+    /**
+     * Energy 32 characteristic
+     *
+     * @param energy Energy in units of kilowatt-hours.
+     */
+    public Energy32(final double energy) {
+        this.value = energy;
+    }
+
+    @NonNull
+    @Override
+    public String toString() {
+        return this.value + " kWh";
+    }
+
+    @Override
+    public int getLength() {
+        return 4;
+    }
+
+    @Override
+    public byte[] getBytes() {
+        byte[] bytes = {(byte) 0xFF, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF};
+        if (this.value != null) {
+            long value = (long) (this.value * 1000.0d + 0.5d);
+            for (int n = 0; n < 4; n++) {
+                bytes[n] = (byte) ((value >> (n * 8)) & 0xFF);
+            }
+        }
+        return bytes;
+    }
+}

--- a/mesh/src/test/java/no/nordicsemi/android/mesh/sensorutils/DevicePropertyCharacteristicTest.java
+++ b/mesh/src/test/java/no/nordicsemi/android/mesh/sensorutils/DevicePropertyCharacteristicTest.java
@@ -180,4 +180,47 @@ public class DevicePropertyCharacteristicTest {
             counter++;
         }
     }
+
+    @Test
+    public void energy32() {
+        final ArrayList<Double> expectedSamples = new ArrayList<>();
+        expectedSamples.add(0.0d);
+        expectedSamples.add(0.001d);
+        expectedSamples.add(2147483.646d);
+        expectedSamples.add(4294967.293d);
+        expectedSamples.add(null);
+        expectedSamples.add(null);
+        final ArrayList<byte[]> samples = new ArrayList<>();
+        samples.add(new byte[]{0x00, 0x00, 0x00, 0x00});
+        samples.add(new byte[]{0x01, 0x00, 0x00, 0x00});
+        samples.add(new byte[]{(byte) 0xFE, (byte) 0xFF, (byte) 0xFF, 0x7F});
+        samples.add(new byte[]{(byte) 0xFD, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF});
+        samples.add(new byte[]{(byte) 0xFE, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF});
+        samples.add(new byte[]{(byte) 0xFF, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF});
+
+        final ArrayList<byte[]> expectedGetBytes = new ArrayList<>();
+        expectedGetBytes.add(new byte[]{0x00, 0x00, 0x00, 0x00});
+        expectedGetBytes.add(new byte[]{0x01, 0x00, 0x00, 0x00});
+        expectedGetBytes.add(new byte[]{(byte) 0xFE, (byte) 0xFF, (byte) 0xFF, 0x7F});
+        expectedGetBytes.add(new byte[]{(byte) 0xFD, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF});
+        // Note: The expected energy32.getBytes for sample 0xFFFFFFFE is 0xFFFFFFFF since we are
+        // using null to represent both non-valid values and have to choose one.
+        expectedGetBytes.add(new byte[]{(byte) 0xFF, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF});
+        expectedGetBytes.add(new byte[]{(byte) 0xFF, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF});
+
+        DeviceProperty[] properties = {
+                DeviceProperty.ACTIVE_ENERGY_LOAD_SIDE,
+                DeviceProperty.PRECISE_TOTAL_DEVICE_ENERGY_USE
+        };
+        for (DeviceProperty property : properties) {
+            int counter = 0;
+            for (byte[] sample : samples) {
+                final DevicePropertyCharacteristic<?> energy32 = DeviceProperty.
+                        getCharacteristic(property, sample, 0, 4);
+                Assert.assertEquals(expectedSamples.get(counter), energy32.getValue());
+                Assert.assertArrayEquals(expectedGetBytes.get(counter), energy32.getBytes());
+                counter++;
+            }
+        }
+    }
 }

--- a/mesh/src/test/java/no/nordicsemi/android/mesh/transport/SchedulerActionStatusTest.java
+++ b/mesh/src/test/java/no/nordicsemi/android/mesh/transport/SchedulerActionStatusTest.java
@@ -10,6 +10,7 @@ import org.mockito.junit.MockitoRule;
 import java.util.ArrayList;
 import java.util.Arrays;
 
+import no.nordicsemi.android.mesh.data.GenericTransitionTime;
 import no.nordicsemi.android.mesh.data.ScheduleEntry;
 
 import static org.junit.Assert.assertEquals;
@@ -37,7 +38,7 @@ public class SchedulerActionStatusTest {
                 .setDayOfWeek(ScheduleEntry.DayOfWeek.Any(new ArrayList<>(
                         Arrays.asList(ScheduleEntry.DayOfWeek.SATURDAY, ScheduleEntry.DayOfWeek.SUNDAY))))
                 .setAction(ScheduleEntry.Action.TurnOn)
-                .setGenericTransitionTime(new ScheduleEntry.TransitionTime(1,8))
+                .setGenericTransitionTime(new GenericTransitionTime(GenericTransitionTime.TransitionResolution.SECOND, GenericTransitionTime.TransitionStep.Specific(8)))
                 .setScene(ScheduleEntry.Scene.Address(0x3333));
 
         Mockito.when(accessMessage.getParameters()).thenReturn(schedulerData);

--- a/mesh/src/test/java/no/nordicsemi/android/mesh/transport/schedulerEntry/EntrySpecTest.java
+++ b/mesh/src/test/java/no/nordicsemi/android/mesh/transport/schedulerEntry/EntrySpecTest.java
@@ -5,6 +5,7 @@ import org.junit.Test;
 import java.util.ArrayList;
 import java.util.Arrays;
 
+import no.nordicsemi.android.mesh.data.GenericTransitionTime;
 import no.nordicsemi.android.mesh.data.ScheduleEntry;
 import no.nordicsemi.android.mesh.utils.BitReader;
 import no.nordicsemi.android.mesh.utils.BitWriter;
@@ -37,7 +38,7 @@ public class EntrySpecTest {
                 .setDayOfWeek(ScheduleEntry.DayOfWeek.Any(new ArrayList<>(
                         Arrays.asList(ScheduleEntry.DayOfWeek.SATURDAY, ScheduleEntry.DayOfWeek.SUNDAY))))
                 .setAction(ScheduleEntry.Action.TurnOn)
-                .setGenericTransitionTime(new ScheduleEntry.TransitionTime(1,8))
+                .setGenericTransitionTime(new GenericTransitionTime(GenericTransitionTime.TransitionResolution.SECOND, GenericTransitionTime.TransitionStep.Specific(8)))
                 .setScene(ScheduleEntry.Scene.Address(0x3333));
        BitWriter bitWriter = new BitWriter();
         entry.assembleMessageParameters(bitWriter);
@@ -70,7 +71,7 @@ public class EntrySpecTest {
                 .setDayOfWeek(ScheduleEntry.DayOfWeek.Any(new ArrayList<>(
                         Arrays.asList(ScheduleEntry.DayOfWeek.SATURDAY, ScheduleEntry.DayOfWeek.SUNDAY))))
                 .setAction(ScheduleEntry.Action.TurnOn)
-                .setGenericTransitionTime(new ScheduleEntry.TransitionTime(1,8))
+                .setGenericTransitionTime(new GenericTransitionTime(GenericTransitionTime.TransitionResolution.SECOND, GenericTransitionTime.TransitionStep.Specific(8)))
                 .setScene(ScheduleEntry.Scene.Address(0x3333));
 
         byte[] testData = new byte[]{(byte)0x33,(byte) 0x33,(byte) 0x48,(byte) 0x1C,(byte) 0x16, (byte) 0xBC, (byte) 0xC4, (byte)0x50,(byte) 0x11,(byte) 0x40};


### PR DESCRIPTION
This PR implements the `Energy32` characteristic and adds two device properties (`Active Energy Loadside` and `Precise Total Device Energy Use`) that depends on it.

![energy32](https://user-images.githubusercontent.com/36726279/152136934-26a86569-1b2a-491f-9c88-676632274c41.jpg)
Part of a screenshot from the example app showing `Energy32` usage.

