### PR TITLE
Add ElectricCurrent characteristic

### DIFF
--- a/mesh/src/main/java/no/nordicsemi/android/mesh/sensorutils/DeviceProperty.java
+++ b/mesh/src/main/java/no/nordicsemi/android/mesh/sensorutils/DeviceProperty.java
@@ -1056,6 +1056,9 @@ public enum DeviceProperty {
             case LUMINAIRE_POWER_AT_MINIMUM_DIM_LEVEL:
             case PRESENT_DEVICE_INPUT_POWER:
                 return new Power(data, offset);
+            case PRESENT_INPUT_CURRENT:
+            case PRESENT_OUTPUT_CURRENT:
+                return new ElectricCurrent(data, offset);
             default:
                 return new UnknownCharacteristic(data, offset, length);
         }

--- a/mesh/src/main/java/no/nordicsemi/android/mesh/sensorutils/DeviceProperty.java
+++ b/mesh/src/main/java/no/nordicsemi/android/mesh/sensorutils/DeviceProperty.java
@@ -1051,6 +1051,11 @@ public enum DeviceProperty {
             case ACTIVE_ENERGY_LOAD_SIDE:
             case PRECISE_TOTAL_DEVICE_ENERGY_USE:
                 return new Energy32(data, offset);
+            case ACTIVE_POWER_LOAD_SIDE:
+            case LUMINAIRE_NOMINAL_INPUT_POWER:
+            case LUMINAIRE_POWER_AT_MINIMUM_DIM_LEVEL:
+            case PRESENT_DEVICE_INPUT_POWER:
+                return new Power(data, offset);
             default:
                 return new UnknownCharacteristic(data, offset, length);
         }

--- a/mesh/src/main/java/no/nordicsemi/android/mesh/sensorutils/DeviceProperty.java
+++ b/mesh/src/main/java/no/nordicsemi/android/mesh/sensorutils/DeviceProperty.java
@@ -1048,6 +1048,9 @@ public enum DeviceProperty {
                 return new FixedString(data, offset, 36);
             case LUMINAIRE_IDENTIFICATION_STRING:
                 return new FixedString(data, offset, 64);
+            case ACTIVE_ENERGY_LOAD_SIDE:
+            case PRECISE_TOTAL_DEVICE_ENERGY_USE:
+                return new Energy32(data, offset);
             default:
                 return new UnknownCharacteristic(data, offset, length);
         }

--- a/mesh/src/main/java/no/nordicsemi/android/mesh/sensorutils/ElectricCurrent.java
+++ b/mesh/src/main/java/no/nordicsemi/android/mesh/sensorutils/ElectricCurrent.java
@@ -1,0 +1,52 @@
+package no.nordicsemi.android.mesh.sensorutils;
+
+import static no.nordicsemi.android.mesh.utils.MeshParserUtils.unsignedBytesToInt;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.RestrictTo;
+
+/**
+ * The Electric Current characteristic is used to represent a measure of current in units of ampere.
+ */
+public class ElectricCurrent extends DevicePropertyCharacteristic<Float> {
+
+    @RestrictTo(RestrictTo.Scope.LIBRARY)
+    public ElectricCurrent(@NonNull final byte[] data, final int offset) {
+        super(data, offset);
+        int bits = unsignedBytesToInt(data[offset], data[offset + 1]);
+        if (bits == 0xFFFF) this.value = null;
+        else this.value = ((float) bits) / 100.0f;
+    }
+
+    /**
+     * Electric current characteristic
+     *
+     * @param current Current in units of ampere.
+     */
+    public ElectricCurrent(final float current) {
+        this.value = current;
+    }
+
+    @NonNull
+    @Override
+    public String toString() {
+        return this.value + " A";
+    }
+
+    @Override
+    public int getLength() {
+        return 2;
+    }
+
+    @Override
+    public byte[] getBytes() {
+        byte[] bytes = {(byte) 0xFF, (byte) 0xFF};
+        if (this.value != null) {
+            int bits = (int) (this.value * 100.0f + 0.5f);
+            for (int n = 0; n < 2; n++) {
+                bytes[n] = (byte) ((bits >> (n * 8)) & 0xFF);
+            }
+        }
+        return bytes;
+    }
+}

--- a/mesh/src/main/java/no/nordicsemi/android/mesh/sensorutils/Energy32.java
+++ b/mesh/src/main/java/no/nordicsemi/android/mesh/sensorutils/Energy32.java
@@ -1,0 +1,54 @@
+package no.nordicsemi.android.mesh.sensorutils;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.RestrictTo;
+
+import java.util.Arrays;
+
+/**
+ * The Energy 32 characteristic is used to represent a measure of energy in units of kilowatt-hours.
+ */
+public class Energy32 extends DevicePropertyCharacteristic<Double> {
+
+    @RestrictTo(RestrictTo.Scope.LIBRARY)
+    public Energy32(@NonNull final byte[] data, final int offset) {
+        super(data, offset);
+        long bits = 0;
+        byte[] bytes = Arrays.copyOfRange(data, offset, offset + getLength());
+        for (byte b : bytes) bits = (bits >> 8) | (((long) b & 0xFF) << 24);
+        if (bits == 0xFFFFFFFFL || bits == 0xFFFFFFFEL) this.value = null;
+        else this.value = ((double) bits) / 1000.0d;
+    }
+
+    /**
+     * Energy 32 characteristic
+     *
+     * @param energy Energy in units of kilowatt-hours.
+     */
+    public Energy32(final double energy) {
+        this.value = energy;
+    }
+
+    @NonNull
+    @Override
+    public String toString() {
+        return this.value + " kWh";
+    }
+
+    @Override
+    public int getLength() {
+        return 4;
+    }
+
+    @Override
+    public byte[] getBytes() {
+        byte[] bytes = {(byte) 0xFF, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF};
+        if (this.value != null) {
+            long value = (long) (this.value * 1000.0d + 0.5d);
+            for (int n = 0; n < 4; n++) {
+                bytes[n] = (byte) ((value >> (n * 8)) & 0xFF);
+            }
+        }
+        return bytes;
+    }
+}

--- a/mesh/src/main/java/no/nordicsemi/android/mesh/sensorutils/Power.java
+++ b/mesh/src/main/java/no/nordicsemi/android/mesh/sensorutils/Power.java
@@ -1,0 +1,50 @@
+package no.nordicsemi.android.mesh.sensorutils;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.RestrictTo;
+
+/**
+ * The Power characteristic is used to represent a measure of power in units of watts.
+ */
+public class Power extends DevicePropertyCharacteristic<Float> {
+
+    @RestrictTo(RestrictTo.Scope.LIBRARY)
+    public Power(@NonNull final byte[] data, final int offset) {
+        super(data, offset);
+        int bits = (((data[offset + 2] & 0xFF) << 16) | ((data[offset + 1] & 0xFF) << 8) | (data[offset] & 0xFF));
+        if (bits == 0xFFFFFF) this.value = null;
+        else this.value = ((float) bits) / 10.0f;
+    }
+
+    /**
+     * Power characteristic
+     *
+     * @param power Power in units of watts.
+     */
+    public Power(final float power) {
+        this.value = power;
+    }
+
+    @NonNull
+    @Override
+    public String toString() {
+        return this.value + " W";
+    }
+
+    @Override
+    public int getLength() {
+        return 3;
+    }
+
+    @Override
+    public byte[] getBytes() {
+        byte[] bytes = {(byte) 0xFF, (byte) 0xFF, (byte) 0xFF};
+        if (this.value != null) {
+            int bits = (int) (this.value * 10.0f + 0.5f);
+            for (int n = 0; n < 3; n++) {
+                bytes[n] = (byte) ((bits >> (n * 8)) & 0xFF);
+            }
+        }
+        return bytes;
+    }
+}

--- a/mesh/src/test/java/no/nordicsemi/android/mesh/sensorutils/DevicePropertyCharacteristicTest.java
+++ b/mesh/src/test/java/no/nordicsemi/android/mesh/sensorutils/DevicePropertyCharacteristicTest.java
@@ -268,4 +268,44 @@ public class DevicePropertyCharacteristicTest {
             }
         }
     }
+
+    @Test
+    public void electricCurrent() {
+        final ArrayList<Float> expectedSamples = new ArrayList<>();
+        expectedSamples.add(0.0f);
+        expectedSamples.add(0.01f);
+        expectedSamples.add(327.67f);
+        expectedSamples.add(655.34f);
+        expectedSamples.add(null);
+        final ArrayList<byte[]> samples = new ArrayList<>();
+        // Note that sample data has been padded with leading and trailing "random" bytes to test
+        // data offset and length.
+        samples.add(new byte[]{0x01, 0x00, 0x00, 0x01});
+        samples.add(new byte[]{0x02, 0x01, 0x00, 0x02});
+        samples.add(new byte[]{0x03, (byte) 0xFF, 0x7F, 0x03});
+        samples.add(new byte[]{0x04, (byte) 0xFE, (byte) 0xFF, 0x04});
+        samples.add(new byte[]{0x05, (byte) 0xFF, (byte) 0xFF, 0x05});
+
+        final ArrayList<byte[]> expectedGetBytes = new ArrayList<>();
+        expectedGetBytes.add(new byte[]{0x00, 0x00});
+        expectedGetBytes.add(new byte[]{0x01, 0x00});
+        expectedGetBytes.add(new byte[]{(byte) 0xFF, 0x7F});
+        expectedGetBytes.add(new byte[]{(byte) 0xFE, (byte) 0xFF});
+        expectedGetBytes.add(new byte[]{(byte) 0xFF, (byte) 0xFF});
+
+        DeviceProperty[] properties = {
+                DeviceProperty.PRESENT_INPUT_CURRENT,
+                DeviceProperty.PRESENT_OUTPUT_CURRENT,
+        };
+        for (DeviceProperty property : properties) {
+            int counter = 0;
+            for (byte[] sample : samples) {
+                final DevicePropertyCharacteristic<?> electricCurrent = DeviceProperty.
+                        getCharacteristic(property, sample, 1, 2);
+                Assert.assertEquals(expectedSamples.get(counter), electricCurrent.getValue());
+                Assert.assertArrayEquals(expectedGetBytes.get(counter), electricCurrent.getBytes());
+                counter++;
+            }
+        }
+    }
 }

--- a/mesh/src/test/java/no/nordicsemi/android/mesh/sensorutils/DevicePropertyCharacteristicTest.java
+++ b/mesh/src/test/java/no/nordicsemi/android/mesh/sensorutils/DevicePropertyCharacteristicTest.java
@@ -180,4 +180,47 @@ public class DevicePropertyCharacteristicTest {
             counter++;
         }
     }
+
+    @Test
+    public void energy32() {
+        final ArrayList<Double> expectedSamples = new ArrayList<>();
+        expectedSamples.add(0.0d);
+        expectedSamples.add(0.001d);
+        expectedSamples.add(2147483.646d);
+        expectedSamples.add(4294967.293d);
+        expectedSamples.add(null);
+        expectedSamples.add(null);
+        final ArrayList<byte[]> samples = new ArrayList<>();
+        samples.add(new byte[]{0x00, 0x00, 0x00, 0x00});
+        samples.add(new byte[]{0x01, 0x00, 0x00, 0x00});
+        samples.add(new byte[]{(byte) 0xFE, (byte) 0xFF, (byte) 0xFF, 0x7F});
+        samples.add(new byte[]{(byte) 0xFD, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF});
+        samples.add(new byte[]{(byte) 0xFE, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF});
+        samples.add(new byte[]{(byte) 0xFF, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF});
+
+        final ArrayList<byte[]> expectedGetBytes = new ArrayList<>();
+        expectedGetBytes.add(new byte[]{0x00, 0x00, 0x00, 0x00});
+        expectedGetBytes.add(new byte[]{0x01, 0x00, 0x00, 0x00});
+        expectedGetBytes.add(new byte[]{(byte) 0xFE, (byte) 0xFF, (byte) 0xFF, 0x7F});
+        expectedGetBytes.add(new byte[]{(byte) 0xFD, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF});
+        // Note: The expected energy32.getBytes for sample 0xFFFFFFFE is 0xFFFFFFFF since we are
+        // using null to represent both non-valid values and have to choose one.
+        expectedGetBytes.add(new byte[]{(byte) 0xFF, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF});
+        expectedGetBytes.add(new byte[]{(byte) 0xFF, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF});
+
+        DeviceProperty[] properties = {
+                DeviceProperty.ACTIVE_ENERGY_LOAD_SIDE,
+                DeviceProperty.PRECISE_TOTAL_DEVICE_ENERGY_USE
+        };
+        for (DeviceProperty property : properties) {
+            int counter = 0;
+            for (byte[] sample : samples) {
+                final DevicePropertyCharacteristic<?> energy32 = DeviceProperty.
+                        getCharacteristic(property, sample, 0, 4);
+                Assert.assertEquals(expectedSamples.get(counter), energy32.getValue());
+                Assert.assertArrayEquals(expectedGetBytes.get(counter), energy32.getBytes());
+                counter++;
+            }
+        }
+    }
 }

--- a/mesh/src/test/java/no/nordicsemi/android/mesh/sensorutils/DevicePropertyCharacteristicTest.java
+++ b/mesh/src/test/java/no/nordicsemi/android/mesh/sensorutils/DevicePropertyCharacteristicTest.java
@@ -223,4 +223,49 @@ public class DevicePropertyCharacteristicTest {
             }
         }
     }
+
+    @Test
+    public void power() {
+        final ArrayList<Float> expectedSamples = new ArrayList<>();
+        expectedSamples.add(0.0f);
+        expectedSamples.add(0.1f);
+        expectedSamples.add(78925.8f);
+        expectedSamples.add(838860.7f);
+        expectedSamples.add(1677721.4f);
+        expectedSamples.add(null);
+        final ArrayList<byte[]> samples = new ArrayList<>();
+        // Note that sample data has been padded with leading and trailing "random" bytes to test
+        // data offset and length.
+        samples.add(new byte[]{0x01, 0x00, 0x00, 0x00, 0x01});
+        samples.add(new byte[]{0x02, 0x01, 0x00, 0x00, 0x02});
+        samples.add(new byte[]{0x02, 0x0A, 0x0B, 0x0C, 0x02});
+        samples.add(new byte[]{0x03, (byte) 0xFF, (byte) 0xFF, 0x7F, 0x03});
+        samples.add(new byte[]{0x04, (byte) 0xFE, (byte) 0xFF, (byte) 0xFF, 0x04});
+        samples.add(new byte[]{0x05, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF, 0x05});
+
+        final ArrayList<byte[]> expectedGetBytes = new ArrayList<>();
+        expectedGetBytes.add(new byte[]{0x00, 0x00, 0x00});
+        expectedGetBytes.add(new byte[]{0x01, 0x00, 0x00});
+        expectedGetBytes.add(new byte[]{0x0A, 0x0B, 0x0C});
+        expectedGetBytes.add(new byte[]{(byte) 0xFF, (byte) 0xFF, 0x7F});
+        expectedGetBytes.add(new byte[]{(byte) 0xFE, (byte) 0xFF, (byte) 0xFF});
+        expectedGetBytes.add(new byte[]{(byte) 0xFF, (byte) 0xFF, (byte) 0xFF});
+
+        DeviceProperty[] properties = {
+                DeviceProperty.ACTIVE_POWER_LOAD_SIDE,
+                DeviceProperty.LUMINAIRE_NOMINAL_INPUT_POWER,
+                DeviceProperty.LUMINAIRE_POWER_AT_MINIMUM_DIM_LEVEL,
+                DeviceProperty.PRESENT_DEVICE_INPUT_POWER,
+        };
+        for (DeviceProperty property : properties) {
+            int counter = 0;
+            for (byte[] sample : samples) {
+                final DevicePropertyCharacteristic<?> power = DeviceProperty.
+                        getCharacteristic(property, sample, 1, 3);
+                Assert.assertEquals(expectedSamples.get(counter), power.getValue());
+                Assert.assertArrayEquals(expectedGetBytes.get(counter), power.getBytes());
+                counter++;
+            }
+        }
+    }
 }


### PR DESCRIPTION
This PR adds the `ElectricCurrent` characteristics and enables these device properties:
- PRESENT_INPUT_CURRENT
- PRESENT_OUTPUT_CURRENT

![electricCurrent](https://user-images.githubusercontent.com/36726279/152773405-3846c666-59d2-4a71-a613-6cba42cac6f1.jpg)
Part of a screenshot from the example app showing Electric Current usage.